### PR TITLE
feat(repo): rajout d'un repo de webElements global à l'échelle du projet

### DIFF
--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/HightestHomePageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/HightestHomePageActions.java
@@ -1,24 +1,14 @@
 package org.exercice.actions.hightest;
 
-import com.aventstack.extentreports.Status;
 import org.exercice.object_repository.hightest.HightestHomePageRepository;
 import org.exercice.utils.AutomTools;
 import org.exercice.utils.LocalDrivers;
-import org.openqa.selenium.NoSuchElementException;
+import org.exercice.utils.ProjectRepository;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.hightest.HightestHomePageRepository.loadHomePageContextObjects;
 
 public class HightestHomePageActions {
-    private static HightestHomePageRepository homePageRepository;
 
-    private static void loadHomePageContextObjects() {
-        try {
-            homePageRepository = new HightestHomePageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "Hightest home page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "Hightest home page objects loaded");
-    }
 
     public void getToHomePage(String url) {
         LocalDrivers.defaultProjectDriver.get(url);
@@ -26,7 +16,7 @@ public class HightestHomePageActions {
     }
 
     public void clickToolBoxButton() {
-        loadHomePageContextObjects();
-        AutomTools.customClick(homePageRepository.toolboxButton);
+        HightestHomePageRepository localContext = loadHomePageContextObjects();
+        AutomTools.customClick(ProjectRepository.getWebElementFromProjectRepo(localContext.getToolboxButton()));
     }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/HightestResultPageAction.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/HightestResultPageAction.java
@@ -1,33 +1,21 @@
 package org.exercice.actions.hightest;
 
-import com.aventstack.extentreports.Status;
 import org.exercice.object_repository.hightest.HighTestResultPageRepository;
 import org.exercice.utils.AutomTools;
-import org.openqa.selenium.NoSuchElementException;
+import org.exercice.utils.ProjectRepository;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.hightest.HighTestResultPageRepository.loadResultPageContextObjects;
 
 public class HightestResultPageAction {
 
-
-    private static HighTestResultPageRepository highTestResultPageRepository;
-
-    private static void loadResultPageContextObjects() {
-        try {
-            highTestResultPageRepository = new HighTestResultPageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "Hightest result page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "Hightest result page objects loaded");
-    }
-
     public void submitEmailAdressToReceiveResults(String adress) {
-        loadResultPageContextObjects();
-        highTestResultPageRepository.emailBox.sendKeys(adress);
+        HighTestResultPageRepository localContext = loadResultPageContextObjects();
+        AutomTools.customSendKeys(ProjectRepository.getWebElementFromProjectRepo(localContext.getEmailBox()), adress);
     }
 
     public void clickOkayButton() {
-        AutomTools.customClick(highTestResultPageRepository.submitButton);
+        HighTestResultPageRepository localContext = loadResultPageContextObjects();
+        AutomTools.customClick(ProjectRepository.getWebElementFromProjectRepo(localContext.getSubmitButton()));
     }
 
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ISTQBQuestionPageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ISTQBQuestionPageActions.java
@@ -1,61 +1,51 @@
 package org.exercice.actions.hightest;
 
-import com.aventstack.extentreports.Status;
 import org.exercice.object_repository.hightest.ISTQBQuestionPageRepository;
-import org.exercice.utils.AutomTools;
 import org.exercice.utils.LocalDrivers;
-import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import java.time.Duration;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.hightest.ISTQBQuestionPageRepository.loadISTQBQuestionsContextObjects;
+import static org.exercice.utils.AutomTools.customClick;
+import static org.exercice.utils.ProjectRepository.getWebElementFromProjectRepo;
 
 public class ISTQBQuestionPageActions {
 
-    private static ISTQBQuestionPageRepository istqbQuestionPageRepository;
-
-    private static void loadISTQBQuestionsContextObjects() {
-        try {
-            istqbQuestionPageRepository = new ISTQBQuestionPageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "ISTQB questions page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "ISTQB questions page objects loaded");
-    }
-
     public void explicitlyWaitForRadioButtonsToBeLoaded() {
-        loadISTQBQuestionsContextObjects();
+        ISTQBQuestionPageRepository localContext = loadISTQBQuestionsContextObjects();
         WebDriverWait wait = new WebDriverWait(LocalDrivers.defaultProjectDriver, Duration.ofSeconds(50));
-        wait.until(ExpectedConditions.elementToBeClickable(istqbQuestionPageRepository.goodAnswerQuestion1));
+        wait.until(ExpectedConditions.elementToBeClickable(localContext.getGoodAnswerQuestion1()));
 
     }
 
     public void clickTerminateButton() {
-        AutomTools.customClick(istqbQuestionPageRepository.terminateButton);
+        ISTQBQuestionPageRepository localContext = loadISTQBQuestionsContextObjects();
+        customClick(getWebElementFromProjectRepo(localContext.getTerminateButton()));
     }
 
-    public void answerAllTestQuestionWithCompleteSuccess() {
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion1);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion2);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion3);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion4);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion5);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion6);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion7);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion8);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion9);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion10);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion11);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion12);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion13);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion14);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion15);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion16);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion17);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion18);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion19);
-        AutomTools.customClick(istqbQuestionPageRepository.goodAnswerQuestion20);
+    public void goodAnswersToAllTestQuestion() {
+        ISTQBQuestionPageRepository localContext = loadISTQBQuestionsContextObjects();
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion1()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion2()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion3()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion4()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion5()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion6()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion7()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion8()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion9()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion10()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion11()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion12()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion13()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion14()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion15()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion16()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion17()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion18()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion19()));
+        customClick(getWebElementFromProjectRepo(localContext.getGoodAnswerQuestion20()));
     }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ToolBoxPageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ToolBoxPageActions.java
@@ -1,27 +1,15 @@
 package org.exercice.actions.hightest;
 
-import com.aventstack.extentreports.Status;
 import org.exercice.object_repository.hightest.ToolBoxRepository;
 import org.exercice.utils.AutomTools;
-import org.openqa.selenium.NoSuchElementException;
+import org.exercice.utils.ProjectRepository;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.hightest.ToolBoxRepository.loadToolBoxContextObjects;
 
 public class ToolBoxPageActions {
 
-    private static ToolBoxRepository toolBoxRepository;
-
-    private static void loadToolBoxContextObjects() {
-        try {
-            toolBoxRepository = new ToolBoxRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "ToolBox page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "Toolbox page objects loaded");
-    }
-
     public void clickISTQBFoundationFrenchButton() {
-        loadToolBoxContextObjects();
-        AutomTools.customClick(toolBoxRepository.iSTQBFoundationFrenchButton);
+        ToolBoxRepository localContext = loadToolBoxContextObjects();
+        AutomTools.customClick(ProjectRepository.getWebElementFromProjectRepo(localContext.getISTQBFoundationFrenchButton()));
     }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/linkedin/LinkedInHomePageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/linkedin/LinkedInHomePageActions.java
@@ -1,35 +1,23 @@
 package org.exercice.actions.linkedin;
 
-import com.aventstack.extentreports.Status;
 import org.exercice.object_repository.linkedin.LinkedInHomePageRepository;
-import org.exercice.utils.AutomTools;
-import org.exercice.utils.LocalDrivers;
-import org.openqa.selenium.NoSuchElementException;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.linkedin.LinkedInHomePageRepository.loadLinkedInHomePageContextObjects;
+import static org.exercice.utils.AutomTools.customClick;
+import static org.exercice.utils.AutomTools.customSendKeys;
+import static org.exercice.utils.LocalDrivers.defaultProjectDriver;
+import static org.exercice.utils.ProjectRepository.getWebElementFromProjectRepo;
 
 public class LinkedInHomePageActions {
 
-    private static LinkedInHomePageRepository homePageRepository;
-
-    private static void loadContextObjects() {
-        try {
-            homePageRepository = new LinkedInHomePageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn home page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "LinkedIn home page objects loaded");
-    }
-
     public void getToHomePage(String url) {
-        LocalDrivers.defaultProjectDriver.get(url);
-        LocalDrivers.defaultProjectDriver.manage().window().maximize();
+        defaultProjectDriver.get(url);
+        defaultProjectDriver.manage().window().maximize();
     }
-
     public void submitLinkedInConnectionInformations(String email, String password) {
-        loadContextObjects();
-        homePageRepository.emailBox.sendKeys(email);
-        homePageRepository.passwordBox.sendKeys(password);
-        AutomTools.customClick(homePageRepository.submitButton);
+        LinkedInHomePageRepository localContext = loadLinkedInHomePageContextObjects();
+        customSendKeys(getWebElementFromProjectRepo(localContext.getEmailBox()), email);
+        customSendKeys(getWebElementFromProjectRepo(localContext.getPasswordBox()), password);
+        customClick(getWebElementFromProjectRepo(localContext.getSubmitButton()));
     }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/linkedin/LinkedInMainPageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/linkedin/LinkedInMainPageActions.java
@@ -1,70 +1,38 @@
 package org.exercice.actions.linkedin;
 
-import com.aventstack.extentreports.Status;
 import net.sourceforge.tess4j.ITesseract;
 import net.sourceforge.tess4j.Tesseract;
 import net.sourceforge.tess4j.TesseractException;
 import org.exercice.object_repository.linkedin.LinkedInChatPageRepository;
 import org.exercice.object_repository.linkedin.LinkedInContactsRepository;
 import org.exercice.object_repository.linkedin.LinkedInMainPageRepository;
-import org.exercice.utils.AutomTools;
-import org.exercice.utils.LocalDrivers;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.interactions.Actions;
 
 import java.io.File;
 
-import static org.exercice.utils.Reporter.testCase;
+import static org.exercice.object_repository.linkedin.LinkedInChatPageRepository.loadChatContextObjects;
+import static org.exercice.object_repository.linkedin.LinkedInContactsRepository.loadContactsContextObjects;
+import static org.exercice.object_repository.linkedin.LinkedInMainPageRepository.loadMainPageContextObjects;
+import static org.exercice.utils.AutomTools.captureCroppedPicture;
+import static org.exercice.utils.AutomTools.customClick;
+import static org.exercice.utils.AutomTools.customDoubleClick;
+import static org.exercice.utils.ProjectRepository.getWebElementFromProjectRepo;
 
 public class LinkedInMainPageActions {
 
-    private static LinkedInMainPageRepository linkedInMainPageRepository;
-    private static LinkedInChatPageRepository linkedInChatPageRepository;
-    private static LinkedInContactsRepository linkedInContactsRepository;
-
-    private static void loadMainPageContextObjects() {
-        try {
-            linkedInMainPageRepository = new LinkedInMainPageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn main page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "LinkedIn main page objects loaded");
-    }
-
-    private static void loadChatContextObjects() {
-        try {
-            linkedInChatPageRepository = new LinkedInChatPageRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn chat page objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "LinkedIn chat page objects loaded");
-    }
-
-    private static void loadContactsContextObjects() {
-        try {
-            linkedInContactsRepository = new LinkedInContactsRepository();
-        } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn contacts objects loading failed : " + e.getMessage());
-        }
-        testCase.log(Status.PASS, "LinkedIn contacts objects loaded");
-    }
-
     public void openChatWindowWithJulienBaroni() {
-        loadMainPageContextObjects();
-        Actions actions = new Actions(LocalDrivers.defaultProjectDriver);
-        actions.doubleClick(linkedInMainPageRepository.chatContact).perform();
+        LinkedInMainPageRepository localContext = loadMainPageContextObjects();
+        customDoubleClick(getWebElementFromProjectRepo(localContext.getChatContactJulienBaroni()));
     }
 
     public void openResults() {
-        loadChatContextObjects();
-        AutomTools.customClick(linkedInChatPageRepository.resultImageInChat);
+        LinkedInChatPageRepository localContext = loadChatContextObjects();
+        customClick(getWebElementFromProjectRepo(localContext.getResultImageInChat()));
     }
 
     public String checkTotalSuccess() throws TesseractException, InterruptedException {
-        // Find the image element
-        loadContactsContextObjects();
-        AutomTools.customClick(linkedInContactsRepository.zoomedImageElement);
-        AutomTools.captureCroppedPicture();
+        LinkedInContactsRepository localContext = loadContactsContextObjects();
+        customClick(getWebElementFromProjectRepo(localContext.getZoomedImageElement()));
+        captureCroppedPicture();
 
         // Use Tesseract OCR to extract text from the image
         ITesseract tesseract = new Tesseract();

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HighTestResultPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HighTestResultPageRepository.java
@@ -1,11 +1,30 @@
 package org.exercice.object_repository.hightest;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class HighTestResultPageRepository {
 
-    public final WebElement emailBox = LocalDrivers.defaultProjectDriver.findElement(By.id("email"));
-    public final WebElement submitButton = LocalDrivers.defaultProjectDriver.findElement(By.id("submitMail"));
+    private final WebElement emailBox = LocalDrivers.defaultProjectDriver.findElement(By.id("email"));
+    private final WebElement submitButton = LocalDrivers.defaultProjectDriver.findElement(By.id("submitMail"));
+
+    public static HighTestResultPageRepository loadResultPageContextObjects() {
+        HighTestResultPageRepository highTestResultPageRepository = null;
+        try {
+            highTestResultPageRepository = new HighTestResultPageRepository();
+            webElementsRepository.put("Hightest result page email box", highTestResultPageRepository.emailBox);
+            webElementsRepository.put("Hightest result page submit button", highTestResultPageRepository.submitButton);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "Hightest result page objects loading failed : " + e.getMessage());
+        }
+        return highTestResultPageRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HightestHomePageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HightestHomePageRepository.java
@@ -1,9 +1,27 @@
 package org.exercice.object_repository.hightest;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class HightestHomePageRepository {
-    public final WebElement toolboxButton = LocalDrivers.defaultProjectDriver.findElement(By.id("menu-item-33"));
+    private final WebElement toolboxButton = LocalDrivers.defaultProjectDriver.findElement(By.id("menu-item-33"));
+
+    public static HightestHomePageRepository loadHomePageContextObjects() {
+        HightestHomePageRepository homePageRepository = null;
+        try {
+            homePageRepository = new HightestHomePageRepository();
+            webElementsRepository.put("Hightest home page toolbox button", homePageRepository.toolboxButton);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "Hightest home page objects loading failed : " + e.getMessage());
+        }
+        return homePageRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ISTQBQuestionPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ISTQBQuestionPageRepository.java
@@ -1,37 +1,69 @@
 package org.exercice.object_repository.hightest;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
 
+@Getter
 public class ISTQBQuestionPageRepository {
-    public final WebElement goodAnswerQuestion1 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='0'][value='1']"));
-    public final WebElement goodAnswerQuestion2 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='1'][value='2']"));
-    public final WebElement goodAnswerQuestion3 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='2'][value='1']"));
 
-    public final WebElement goodAnswerQuestion4 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='3'][value='2']"));
+    private final WebElement goodAnswerQuestion1 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='0'][value='1']"));
+    private final WebElement goodAnswerQuestion2 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='1'][value='2']"));
+    private final WebElement goodAnswerQuestion3 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='2'][value='1']"));
+    private final WebElement goodAnswerQuestion4 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='3'][value='2']"));
+    private final WebElement goodAnswerQuestion5 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='4'][value='2']"));
+    private final WebElement goodAnswerQuestion6 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='5'][value='3']"));
+    private final WebElement goodAnswerQuestion7 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='6'][value='2']"));
+    private final WebElement goodAnswerQuestion8 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='7'][value='4']"));
+    private final WebElement goodAnswerQuestion9 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='8'][value='1']"));
+    private final WebElement goodAnswerQuestion10 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='9'][value='3']"));
+    private final WebElement goodAnswerQuestion11 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='10'][value='4']"));
+    private final WebElement goodAnswerQuestion12 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='11'][value='2']"));
+    private final WebElement goodAnswerQuestion13 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='12'][value='3']"));
+    private final WebElement goodAnswerQuestion14 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='13'][value='2']"));
+    private final WebElement goodAnswerQuestion15 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='14'][value='4']"));
+    private final WebElement goodAnswerQuestion16 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='15'][value='3']"));
+    private final WebElement goodAnswerQuestion17 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='16'][value='3']"));
+    private final WebElement goodAnswerQuestion18 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='17'][value='1']"));
+    private final WebElement goodAnswerQuestion19 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='18'][value='2']"));
+    private final WebElement goodAnswerQuestion20 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='19'][value='2']"));
+    private final WebElement terminateButton = LocalDrivers.defaultProjectDriver.findElement(By.id("submit"));
 
-    public final WebElement goodAnswerQuestion5 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='4'][value='2']"));
-
-    public final WebElement goodAnswerQuestion6 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='5'][value='3']"));
-
-    public final WebElement goodAnswerQuestion7 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='6'][value='2']"));
-
-    public final WebElement goodAnswerQuestion8 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='7'][value='4']"));
-    public final WebElement goodAnswerQuestion9 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='8'][value='1']"));
-    public final WebElement goodAnswerQuestion10 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='9'][value='3']"));
-    public final WebElement goodAnswerQuestion11 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='10'][value='4']"));
-    public final WebElement goodAnswerQuestion12 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='11'][value='2']"));
-    public final WebElement goodAnswerQuestion13 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='12'][value='3']"));
-    public final WebElement goodAnswerQuestion14 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='13'][value='2']"));
-    public final WebElement goodAnswerQuestion15 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='14'][value='4']"));
-    public final WebElement goodAnswerQuestion16 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='15'][value='3']"));
-    public final WebElement goodAnswerQuestion17 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='16'][value='3']"));
-    public final WebElement goodAnswerQuestion18 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='17'][value='1']"));
-    public final WebElement goodAnswerQuestion19 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='18'][value='2']"));
-    public final WebElement goodAnswerQuestion20 = LocalDrivers.defaultProjectDriver.findElement(By.cssSelector("input[type='radio'][name='19'][value='2']"));
-
-    public final WebElement terminateButton = LocalDrivers.defaultProjectDriver.findElement(By.id("submit"));
+    public static ISTQBQuestionPageRepository loadISTQBQuestionsContextObjects() {
+        ISTQBQuestionPageRepository istqbQuestionPageRepository = null;
+        try {
+            istqbQuestionPageRepository = new ISTQBQuestionPageRepository();
+            webElementsRepository.put("Radio button for answering correctly to question 1", istqbQuestionPageRepository.goodAnswerQuestion1);
+            webElementsRepository.put("Radio button for answering correctly to question 2", istqbQuestionPageRepository.goodAnswerQuestion2);
+            webElementsRepository.put("Radio button for answering correctly to question 3", istqbQuestionPageRepository.goodAnswerQuestion3);
+            webElementsRepository.put("Radio button for answering correctly to question 4", istqbQuestionPageRepository.goodAnswerQuestion4);
+            webElementsRepository.put("Radio button for answering correctly to question 5", istqbQuestionPageRepository.goodAnswerQuestion5);
+            webElementsRepository.put("Radio button for answering correctly to question 6", istqbQuestionPageRepository.goodAnswerQuestion6);
+            webElementsRepository.put("Radio button for answering correctly to question 7", istqbQuestionPageRepository.goodAnswerQuestion7);
+            webElementsRepository.put("Radio button for answering correctly to question 8", istqbQuestionPageRepository.goodAnswerQuestion8);
+            webElementsRepository.put("Radio button for answering correctly to question 9", istqbQuestionPageRepository.goodAnswerQuestion9);
+            webElementsRepository.put("Radio button for answering correctly to question 10", istqbQuestionPageRepository.goodAnswerQuestion10);
+            webElementsRepository.put("Radio button for answering correctly to question 11", istqbQuestionPageRepository.goodAnswerQuestion11);
+            webElementsRepository.put("Radio button for answering correctly to question 12", istqbQuestionPageRepository.goodAnswerQuestion12);
+            webElementsRepository.put("Radio button for answering correctly to question 13", istqbQuestionPageRepository.goodAnswerQuestion13);
+            webElementsRepository.put("Radio button for answering correctly to question 14", istqbQuestionPageRepository.goodAnswerQuestion14);
+            webElementsRepository.put("Radio button for answering correctly to question 15", istqbQuestionPageRepository.goodAnswerQuestion15);
+            webElementsRepository.put("Radio button for answering correctly to question 16", istqbQuestionPageRepository.goodAnswerQuestion16);
+            webElementsRepository.put("Radio button for answering correctly to question 17", istqbQuestionPageRepository.goodAnswerQuestion17);
+            webElementsRepository.put("Radio button for answering correctly to question 18", istqbQuestionPageRepository.goodAnswerQuestion18);
+            webElementsRepository.put("Radio button for answering correctly to question 19", istqbQuestionPageRepository.goodAnswerQuestion19);
+            webElementsRepository.put("Radio button for answering correctly to question 20", istqbQuestionPageRepository.goodAnswerQuestion20);
+            webElementsRepository.put("Terminé button", istqbQuestionPageRepository.terminateButton);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "ISTQB questions page objects loading failed : " + e.getMessage());
+        }
+        return istqbQuestionPageRepository;
+    }
 
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ToolBoxRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ToolBoxRepository.java
@@ -1,10 +1,28 @@
 package org.exercice.object_repository.hightest;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class ToolBoxRepository {
 
-    public final WebElement iSTQBFoundationFrenchButton = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//*[@id=\"page\"]/div[2]/div/section/article/div[2]/div/div[1]/div/div[2]/div/a[1]"));
+    private final WebElement iSTQBFoundationFrenchButton = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//*[@id=\"page\"]/div[2]/div/section/article/div[2]/div/div[1]/div/div[2]/div/a[1]"));
+
+    public static ToolBoxRepository loadToolBoxContextObjects() {
+        ToolBoxRepository toolBoxRepository = null;
+        try {
+            toolBoxRepository = new ToolBoxRepository();
+            webElementsRepository.put("Button to access the ISTQB Foundation level quizz in French", toolBoxRepository.iSTQBFoundationFrenchButton);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "ToolBox page objects loading failed : " + e.getMessage());
+        }
+        return toolBoxRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInChatPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInChatPageRepository.java
@@ -1,10 +1,29 @@
 package org.exercice.object_repository.linkedin;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class LinkedInChatPageRepository {
 
-    final public WebElement resultImageInChat = LocalDrivers.defaultProjectDriver.findElement(By.className("msg-s-event-listitem__image-container"));
+
+    private final WebElement resultImageInChat = LocalDrivers.defaultProjectDriver.findElement(By.className("msg-s-event-listitem__image-container"));
+
+    public static LinkedInChatPageRepository loadChatContextObjects() {
+        LinkedInChatPageRepository linkedInChatPageRepository = null;
+        try {
+            linkedInChatPageRepository = new LinkedInChatPageRepository();
+            webElementsRepository.put("image from the linkedIn chat", linkedInChatPageRepository.resultImageInChat);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "LinkedIn chat page objects loading failed : " + e.getMessage());
+        }
+        return linkedInChatPageRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInContactsRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInContactsRepository.java
@@ -1,10 +1,27 @@
 package org.exercice.object_repository.linkedin;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
-public class LinkedInContactsRepository {
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
 
-    public final WebElement zoomedImageElement = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//img[@alt='Aperçu de la photo jointe']\n"));
+@Getter
+public class LinkedInContactsRepository {
+    private final WebElement zoomedImageElement = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//img[@alt='Aperçu de la photo jointe']\n"));
+
+    public static LinkedInContactsRepository loadContactsContextObjects() {
+        LinkedInContactsRepository linkedInContactsRepository = null;
+        try {
+            linkedInContactsRepository = new LinkedInContactsRepository();
+            webElementsRepository.put("Fullscreen image from the linkedIn chat when you click on it", linkedInContactsRepository.zoomedImageElement);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "LinkedIn contacts objects loading failed : " + e.getMessage());
+        }
+        return linkedInContactsRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInHomePageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInHomePageRepository.java
@@ -1,11 +1,32 @@
 package org.exercice.object_repository.linkedin;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class LinkedInHomePageRepository {
-    public final WebElement emailBox = LocalDrivers.defaultProjectDriver.findElement(By.id("session_key"));
-    public final WebElement passwordBox = LocalDrivers.defaultProjectDriver.findElement(By.id("session_password"));
-    public final WebElement submitButton = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//*[@id=\"main-content\"]/section[1]/div/div/form/div[2]/button"));
+
+    private final WebElement emailBox = LocalDrivers.defaultProjectDriver.findElement(By.id("session_key"));
+    private final WebElement passwordBox = LocalDrivers.defaultProjectDriver.findElement(By.id("session_password"));
+    private final WebElement submitButton = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//*[@id=\"main-content\"]/section[1]/div/div/form/div[2]/button"));
+
+    public static LinkedInHomePageRepository loadLinkedInHomePageContextObjects() {
+        LinkedInHomePageRepository homePageRepository = null;
+        try {
+            homePageRepository = new LinkedInHomePageRepository();
+            webElementsRepository.put("Box where to put email in order to login on the LinkedIn website", homePageRepository.emailBox);
+            webElementsRepository.put("Box where to put password in order to login on the LinkedIn website", homePageRepository.passwordBox);
+            webElementsRepository.put("Submit button to login on the LinkedIn website", homePageRepository.submitButton);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "LinkedIn home page objects loading failed : " + e.getMessage());
+        }
+        return homePageRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInMainPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInMainPageRepository.java
@@ -1,10 +1,28 @@
 package org.exercice.object_repository.linkedin;
 
+import com.aventstack.extentreports.Status;
+import lombok.Getter;
 import org.exercice.utils.LocalDrivers;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 
+import static org.exercice.utils.ProjectRepository.webElementsRepository;
+import static org.exercice.utils.Reporter.testCase;
+
+@Getter
 public class LinkedInMainPageRepository {
 
-    final public WebElement chatContact = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//h3[contains(.,'Julien Baroni')]"));
+    private final WebElement chatContactJulienBaroni = LocalDrivers.defaultProjectDriver.findElement(By.xpath("//h3[contains(.,'Julien Baroni')]"));
+
+    public static LinkedInMainPageRepository loadMainPageContextObjects() {
+        LinkedInMainPageRepository linkedInMainPageRepository = null;
+        try {
+            linkedInMainPageRepository = new LinkedInMainPageRepository();
+            webElementsRepository.put("chat window with the contact Julien Baroni on LinkedIn", linkedInMainPageRepository.chatContactJulienBaroni);
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "LinkedIn main page objects loading failed : " + e.getMessage());
+        }
+        return linkedInMainPageRepository;
+    }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/AutomTools.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/AutomTools.java
@@ -7,6 +7,7 @@ import org.openqa.selenium.ElementNotInteractableException;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -18,37 +19,43 @@ import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Map;
 
+import static org.exercice.utils.LocalDrivers.defaultProjectDriver;
 import static org.exercice.utils.Reporter.testCase;
 
 @UtilityClass
 public class AutomTools {
 
     public static void makeDriverChrome() {
-        LocalDrivers.defaultProjectDriver = new ChromeDriver();
+        defaultProjectDriver = new ChromeDriver();
     }
 
     public static void closeDriver() {
-        LocalDrivers.defaultProjectDriver.quit();
+        defaultProjectDriver.quit();
     }
 
     public static void driverImplicitWaitConfig(Duration duration) {
-        LocalDrivers.defaultProjectDriver.manage().timeouts().implicitlyWait(duration);
+        defaultProjectDriver.manage().timeouts().implicitlyWait(duration);
     }
 
-    private void configuredClick(WebElement webElement) {
-        Actions actions = new Actions(LocalDrivers.defaultProjectDriver);
-        actions.moveToElement(webElement);
-        actions.perform();
-        webElement.click();
-        testCase.log(Status.PASS, "Successful click on : " + webElement + " element");
+    private void configuredClick(Map.Entry<String, WebElement> entry) {
+        Actions actions = new Actions(defaultProjectDriver);
+        actions.moveToElement(entry.getValue());
+        try {
+            actions.perform();
+        } catch (StaleElementReferenceException e) {
+            testCase.log(Status.FAIL, entry.getKey() + " was previously located, but can not be currently accessed");
+        }
+        entry.getValue().click();
+        testCase.log(Status.PASS, "Successful click on : " + entry.getKey() + " element");
     }
 
     public static void captureCroppedPicture() throws InterruptedException {
         BufferedImage image = null;
         // get the entire screenshot from the driver of passed WebElement
         Thread.sleep(3000);
-        File screen = ((TakesScreenshot) LocalDrivers.defaultProjectDriver)
+        File screen = ((TakesScreenshot) defaultProjectDriver)
                 .getScreenshotAs(OutputType.FILE);
         testCase.log(Status.PASS, "Success in taking a screenshot");
 
@@ -72,27 +79,42 @@ public class AutomTools {
             testCase.log(Status.FAIL, "Could not save image from screenshot in output folder");
         }
         testCase.log(Status.PASS, "Success in saving the screenshot");
+    }
+
+    public static void customDoubleClick(Map.Entry<String, WebElement> entry) {
+        Actions actions = new Actions(defaultProjectDriver);
+        actions.doubleClick(entry.getValue()).perform();
+    }
 
 
+    public static void customSendKeys(Map.Entry<String, WebElement> entry, String content) {
+        try {
+            entry.getValue().sendKeys(content);
+            testCase.log(Status.PASS, "Success in sending keys : " + content + " " + "to web element : " + entry.getKey());
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is not present");
+        } catch (ElementNotInteractableException e) {
+            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is present but not usage to send keys");
+        }
     }
 
 
     public static void switchTabFocus(Integer tab) {
-        ArrayList<String> tabs = new ArrayList<>(LocalDrivers.defaultProjectDriver.getWindowHandles());
-        LocalDrivers.defaultProjectDriver.switchTo().window(tabs.get(tab));
+        ArrayList<String> tabs = new ArrayList<>(defaultProjectDriver.getWindowHandles());
+        defaultProjectDriver.switchTo().window(tabs.get(tab));
         testCase.log(Status.PASS, "Success in switching tab focus");
     }
 
-    public static void customClick(WebElement webElement) {
+    public static void customClick(Map.Entry<String, WebElement> entry) {
         try {
-            configuredClick(webElement);
+            configuredClick(entry);
         } catch (ElementClickInterceptedException e) {
-            ((JavascriptExecutor) LocalDrivers.defaultProjectDriver).executeScript("arguments[0].scrollIntoView(true);", webElement);
-            configuredClick(webElement);
+            ((JavascriptExecutor) defaultProjectDriver).executeScript("arguments[0].scrollIntoView(true);", entry.getValue());
+            configuredClick(entry);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "Element :" + webElement.getAccessibleName() + " is not present");
+            testCase.log(Status.FAIL, "Element :" + entry.getKey() + " is not present");
         } catch (ElementNotInteractableException e) {
-            testCase.log(Status.FAIL, "Element :" + webElement.getAccessibleName() + " is present but not clickable");
+            testCase.log(Status.FAIL, "Element :" + entry.getKey() + " is present but not clickable");
         }
     }
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/ProjectRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/ProjectRepository.java
@@ -1,0 +1,25 @@
+package org.exercice.utils;
+
+import lombok.experimental.UtilityClass;
+import org.openqa.selenium.WebElement;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+@UtilityClass
+public class ProjectRepository {
+
+    public static Map<String, WebElement> webElementsRepository = new HashMap<>();
+
+    public static Map.Entry<String, WebElement> getWebElementFromProjectRepo(WebElement webElement) {
+        Iterator iter = webElementsRepository.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry entry = (Map.Entry) iter.next();
+            if (entry.getValue() == webElement) {
+                return entry;
+            }
+        }
+        return null;
+    }
+}

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/Reporter.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/Reporter.java
@@ -3,7 +3,9 @@ package org.exercice.utils;
 import com.aventstack.extentreports.ExtentReports;
 import com.aventstack.extentreports.ExtentTest;
 import com.aventstack.extentreports.reporter.ExtentSparkReporter;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public class Reporter {
 
     public static ExtentReports extent = new ExtentReports();

--- a/Parcours_IHM_Hightest/src/test/java/org/exercice/EndtoEndIntegTest.java
+++ b/Parcours_IHM_Hightest/src/test/java/org/exercice/EndtoEndIntegTest.java
@@ -51,7 +51,7 @@ class EndtoEndIntegTest {
         AutomTools.switchTabFocus(1);
         ISTQBQuestionPageActions onISTQBQuestionPage = new ISTQBQuestionPageActions();
         onISTQBQuestionPage.explicitlyWaitForRadioButtonsToBeLoaded();
-        onISTQBQuestionPage.answerAllTestQuestionWithCompleteSuccess();
+        onISTQBQuestionPage.goodAnswersToAllTestQuestion();
         onISTQBQuestionPage.clickTerminateButton();
         HightestResultPageAction onHightestResultPage = new HightestResultPageAction();
         onHightestResultPage.submitEmailAdressToReceiveResults("jul.baroni@orange.fr");


### PR DESCRIPTION
Cette PR a pour objectif de décaler la logique d'implémentation de repository depuis les classes d'action vers les classes de repository. Elle permet de mettre à jour deux concepts :

Un repository à l'échelle du projet qui contient un couple de donnée pour chaque élément du parcours. Ce couple correspond à une description utile au log et le webElement, sous forme d'Entry

Le chargement d'un localContext pour chaque action afin de s'assurer que tous les éléments nécessaires à son exécution sont présents