### PR TITLE
feat(testRunner): rajout de la raison d'échec en cas d'erreur à une étape du parcours

### DIFF
--- a/Parcours_IHM_Hightest/pom.xml
+++ b/Parcours_IHM_Hightest/pom.xml
@@ -15,21 +15,10 @@
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.2</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
@@ -39,11 +28,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>2.0.11</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.tess4j</groupId>
@@ -61,6 +45,33 @@
             <artifactId>extentreports</artifactId>
             <version>5.0.9</version>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>7.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-suite</artifactId>
+            <version>1.10.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -73,22 +84,11 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
-
         </plugins>
     </build>
 
     <reporting>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.7.1</version>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ISTQBQuestionPageActions.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/actions/hightest/ISTQBQuestionPageActions.java
@@ -2,6 +2,7 @@ package org.exercice.actions.hightest;
 
 import org.exercice.object_repository.hightest.ISTQBQuestionPageRepository;
 import org.exercice.utils.LocalDrivers;
+import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
@@ -13,9 +14,9 @@ import static org.exercice.utils.ProjectRepository.getWebElementFromProjectRepo;
 
 public class ISTQBQuestionPageActions {
 
-    public void explicitlyWaitForRadioButtonsToBeLoaded() {
+    public void explicitlyWaitForRadioButtonsToBeLoaded() throws NoSuchWindowException {
         ISTQBQuestionPageRepository localContext = loadISTQBQuestionsContextObjects();
-        WebDriverWait wait = new WebDriverWait(LocalDrivers.defaultProjectDriver, Duration.ofSeconds(50));
+        WebDriverWait wait = new WebDriverWait(LocalDrivers.defaultProjectDriver, Duration.ofSeconds(10));
         wait.until(ExpectedConditions.elementToBeClickable(localContext.getGoodAnswerQuestion1()));
 
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HighTestResultPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HighTestResultPageRepository.java
@@ -23,7 +23,7 @@ public class HighTestResultPageRepository {
             webElementsRepository.put("Hightest result page email box", highTestResultPageRepository.emailBox);
             webElementsRepository.put("Hightest result page submit button", highTestResultPageRepository.submitButton);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "Hightest result page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "Hightest result page objects loading failed : " + e.getCause());
         }
         return highTestResultPageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HightestHomePageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/HightestHomePageRepository.java
@@ -20,7 +20,7 @@ public class HightestHomePageRepository {
             homePageRepository = new HightestHomePageRepository();
             webElementsRepository.put("Hightest home page toolbox button", homePageRepository.toolboxButton);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "Hightest home page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "Hightest home page objects loading failed : " + e.getCause());
         }
         return homePageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ISTQBQuestionPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ISTQBQuestionPageRepository.java
@@ -61,7 +61,7 @@ public class ISTQBQuestionPageRepository {
             webElementsRepository.put("Radio button for answering correctly to question 20", istqbQuestionPageRepository.goodAnswerQuestion20);
             webElementsRepository.put("Terminé button", istqbQuestionPageRepository.terminateButton);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "ISTQB questions page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "ISTQB questions page objects loading failed : " + e.getCause());
         }
         return istqbQuestionPageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ToolBoxRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/hightest/ToolBoxRepository.java
@@ -21,7 +21,7 @@ public class ToolBoxRepository {
             toolBoxRepository = new ToolBoxRepository();
             webElementsRepository.put("Button to access the ISTQB Foundation level quizz in French", toolBoxRepository.iSTQBFoundationFrenchButton);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "ToolBox page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "ToolBox page objects loading failed : " + e.getCause());
         }
         return toolBoxRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInChatPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInChatPageRepository.java
@@ -22,7 +22,7 @@ public class LinkedInChatPageRepository {
             linkedInChatPageRepository = new LinkedInChatPageRepository();
             webElementsRepository.put("image from the linkedIn chat", linkedInChatPageRepository.resultImageInChat);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn chat page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "LinkedIn chat page objects loading failed : " + e.getCause());
         }
         return linkedInChatPageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInContactsRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInContactsRepository.java
@@ -20,7 +20,7 @@ public class LinkedInContactsRepository {
             linkedInContactsRepository = new LinkedInContactsRepository();
             webElementsRepository.put("Fullscreen image from the linkedIn chat when you click on it", linkedInContactsRepository.zoomedImageElement);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn contacts objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "LinkedIn contacts objects loading failed : " + e.getCause());
         }
         return linkedInContactsRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInHomePageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInHomePageRepository.java
@@ -25,7 +25,7 @@ public class LinkedInHomePageRepository {
             webElementsRepository.put("Box where to put password in order to login on the LinkedIn website", homePageRepository.passwordBox);
             webElementsRepository.put("Submit button to login on the LinkedIn website", homePageRepository.submitButton);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn home page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "LinkedIn home page objects loading failed : " + e.getCause());
         }
         return homePageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInMainPageRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/object_repository/linkedin/LinkedInMainPageRepository.java
@@ -21,7 +21,7 @@ public class LinkedInMainPageRepository {
             linkedInMainPageRepository = new LinkedInMainPageRepository();
             webElementsRepository.put("chat window with the contact Julien Baroni on LinkedIn", linkedInMainPageRepository.chatContactJulienBaroni);
         } catch (NoSuchElementException e) {
-            testCase.log(Status.FAIL, "LinkedIn main page objects loading failed : " + e.getMessage());
+            testCase.log(Status.FAIL, "LinkedIn main page objects loading failed : " + e.getCause());
         }
         return linkedInMainPageRepository;
     }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/AutomTools.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/AutomTools.java
@@ -82,8 +82,16 @@ public class AutomTools {
     }
 
     public static void customDoubleClick(Map.Entry<String, WebElement> entry) {
-        Actions actions = new Actions(defaultProjectDriver);
-        actions.doubleClick(entry.getValue()).perform();
+        try {
+            Actions actions = new Actions(defaultProjectDriver);
+            actions.doubleClick(entry.getValue()).perform();
+            testCase.log(Status.PASS, "Success in double clicking on : " + entry.getKey() + " " + " element : ");
+        } catch (NoSuchElementException e) {
+            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is not present");
+        } catch (ElementNotInteractableException e) {
+            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is present but not usable to double click");
+        }
+
     }
 
 
@@ -94,7 +102,7 @@ public class AutomTools {
         } catch (NoSuchElementException e) {
             testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is not present");
         } catch (ElementNotInteractableException e) {
-            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is present but not usage to send keys");
+            testCase.log(Status.FAIL, "Element : " + entry.getKey() + " is present but not usable to send keys");
         }
     }
 

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/LocalDrivers.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/LocalDrivers.java
@@ -10,6 +10,6 @@ import org.openqa.selenium.WebDriver;
 @UtilityClass
 public class LocalDrivers {
 
-    public static WebDriver defaultProjectDriver;
+    public WebDriver defaultProjectDriver;
 
 }

--- a/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/ProjectRepository.java
+++ b/Parcours_IHM_Hightest/src/main/java/org/exercice/utils/ProjectRepository.java
@@ -4,7 +4,6 @@ import lombok.experimental.UtilityClass;
 import org.openqa.selenium.WebElement;
 
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 @UtilityClass
@@ -13,9 +12,7 @@ public class ProjectRepository {
     public static Map<String, WebElement> webElementsRepository = new HashMap<>();
 
     public static Map.Entry<String, WebElement> getWebElementFromProjectRepo(WebElement webElement) {
-        Iterator iter = webElementsRepository.entrySet().iterator();
-        while (iter.hasNext()) {
-            Map.Entry entry = (Map.Entry) iter.next();
+        for (Map.Entry<String, WebElement> entry : webElementsRepository.entrySet()) {
             if (entry.getValue() == webElement) {
                 return entry;
             }

--- a/Parcours_IHM_Hightest/src/test/java/org/exercice/GherkinSteps.java
+++ b/Parcours_IHM_Hightest/src/test/java/org/exercice/GherkinSteps.java
@@ -1,7 +1,9 @@
 package org.exercice;
 
-
 import com.aventstack.extentreports.Status;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import net.sourceforge.tess4j.TesseractException;
 import org.exercice.actions.hightest.HightestHomePageActions;
 import org.exercice.actions.hightest.HightestResultPageAction;
@@ -10,62 +12,59 @@ import org.exercice.actions.hightest.ToolBoxPageActions;
 import org.exercice.actions.linkedin.LinkedInHomePageActions;
 import org.exercice.actions.linkedin.LinkedInMainPageActions;
 import org.exercice.utils.AutomTools;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchWindowException;
 
-import java.io.IOException;
-import java.time.Duration;
-
-import static org.exercice.utils.AutomTools.driverImplicitWaitConfig;
-import static org.exercice.utils.AutomTools.makeDriverChrome;
-import static org.exercice.utils.Reporter.extent;
-import static org.exercice.utils.Reporter.extentSparkReporter;
 import static org.exercice.utils.Reporter.testCase;
 
+public class GherkinSteps {
 
-class EndtoEndIntegTest {
-
-
-    @BeforeAll
-    public static void configAndInit() {
-        makeDriverChrome();
-        driverImplicitWaitConfig(Duration.ofSeconds(15));
-        extent.attachReporter(extentSparkReporter);
-
-
-    }
-
-    @AfterAll
-    public static void finish() {
-        AutomTools.closeDriver();
-        extent.flush();
-
-    }
-
-    @Test
-    void shouldGetToEndOfScenarioWithTotalSuccess() throws TesseractException, IOException, InterruptedException {
-        testCase = extent.createTest("Parcours bout en bout");
+    @Given("^I connect to Hightest$")
+    public void i_connect_to_Hightest() {
         HightestHomePageActions onHomePage = new HightestHomePageActions();
         onHomePage.getToHomePage("https://hightest.nc/");
         onHomePage.clickToolBoxButton();
+    }
+
+    @When("^I go to the ToolBox section$")
+    public void i_go_to_the_ToolBox_section() {
         ToolBoxPageActions onToolBoxPage = new ToolBoxPageActions();
         onToolBoxPage.clickISTQBFoundationFrenchButton();
         AutomTools.switchTabFocus(1);
+    }
+
+    @When("^I take the French ISTQB Quizz and all my answers are good$")
+    public void i_take_the_French_ISTQB_Quizz() throws NoSuchWindowException {
         ISTQBQuestionPageActions onISTQBQuestionPage = new ISTQBQuestionPageActions();
         onISTQBQuestionPage.explicitlyWaitForRadioButtonsToBeLoaded();
         onISTQBQuestionPage.goodAnswersToAllTestQuestion();
         onISTQBQuestionPage.clickTerminateButton();
+    }
+
+    @When("^I give Julien Baroni's email for him to receive the results$")
+    public void i_give_Julien_Baroni_s_email_for_him_to_receive_the_results() {
         HightestResultPageAction onHightestResultPage = new HightestResultPageAction();
         onHightestResultPage.submitEmailAdressToReceiveResults("jul.baroni@orange.fr");
         onHightestResultPage.clickOkayButton();
+    }
+
+    @When("^I connect to LinkedIn$")
+    public void i_connect_to_LinkedIn() {
         LinkedInHomePageActions onLinkedInHomePage = new LinkedInHomePageActions();
         onLinkedInHomePage.getToHomePage("https://www.linkedin.com/home");
         onLinkedInHomePage.submitLinkedInConnectionInformations("TestIhmLinkedIn@gmail.com", "Parcours123!");
+    }
+
+    @When("^I open the results Julien Baroni sent me$")
+    public void i_open_the_results_Julien_Baroni_sent_me() {
         LinkedInMainPageActions onLinkedInMainPage = new LinkedInMainPageActions();
         onLinkedInMainPage.openChatWindowWithJulienBaroni();
         onLinkedInMainPage.openResults();
-        if (onLinkedInMainPage.checkTotalSuccess().contains("20 question(s) sur 20, soit 100 % de réussite")) {
+    }
+
+    @Then("^then content of the results indicates \"([^\"]*)\"$")
+    public void then_content_of_the_results_indicates(String arg) throws TesseractException, InterruptedException {
+        LinkedInMainPageActions onLinkedInMainPage = new LinkedInMainPageActions();
+        if (onLinkedInMainPage.checkTotalSuccess().contains(arg)) {
             testCase.log(Status.PASS, "The total score is 100%");
             testCase.addScreenCaptureFromPath("classpath:ResultImage.png");
         } else {

--- a/Parcours_IHM_Hightest/src/test/java/org/exercice/TestRunner.java
+++ b/Parcours_IHM_Hightest/src/test/java/org/exercice/TestRunner.java
@@ -1,0 +1,119 @@
+package org.exercice;
+
+import com.aventstack.extentreports.Status;
+import io.cucumber.core.backend.TestCaseState;
+import io.cucumber.core.gherkin.Pickle;
+import io.cucumber.core.gherkin.Step;
+import io.cucumber.java.After;
+import io.cucumber.java.AfterStep;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import io.cucumber.plugin.event.PickleStepTestStep;
+import io.cucumber.plugin.event.TestCase;
+import org.exercice.utils.AutomTools;
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectClasspathResource;
+import org.junit.platform.suite.api.Suite;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
+import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
+import static org.exercice.utils.AutomTools.driverImplicitWaitConfig;
+import static org.exercice.utils.AutomTools.makeDriverChrome;
+import static org.exercice.utils.LocalDrivers.defaultProjectDriver;
+import static org.exercice.utils.Reporter.extent;
+import static org.exercice.utils.Reporter.extentSparkReporter;
+import static org.exercice.utils.Reporter.testCase;
+
+@Suite
+@IncludeEngines("cucumber")
+@SelectClasspathResource("features")
+@ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "org.exercice")
+@ConfigurationParameter(key = PLUGIN_PROPERTY_NAME, value = "pretty, json:reports/tests/cucumber/json/cucumberTestReport.json")
+public class TestRunner {
+
+    private int currentStepDefIndex = 0;
+
+    @Before("@Exercice")
+    public void setupForUI() {
+        makeDriverChrome();
+        driverImplicitWaitConfig(Duration.ofSeconds(15));
+        testCase = extent.createTest("Parcours bout en bout");
+        extent.attachReporter(extentSparkReporter);
+    }
+
+    @AfterStep("@Exercice")
+    public void afterStep(Scenario scenario) throws IOException, IllegalAccessException, NoSuchFieldException {
+        // Perform actions after each step, regardless of pass/fail status
+
+        if (scenario.isFailed()) {
+            File errorScreenShot = ((TakesScreenshot) defaultProjectDriver)
+                    .getScreenshotAs(OutputType.FILE);
+            BufferedImage errorImage = ImageIO.read(errorScreenShot);
+            ImageIO.write(errorImage, "png", new File("src/test/resources/output/screenshotOfError.png"));
+            testCase.addScreenCaptureFromPath("src/test/resources/output/ResultImage.png");
+
+            final byte[] screenshot = ((TakesScreenshot) defaultProjectDriver)
+                    .getScreenshotAs(OutputType.BYTES);
+            scenario.attach(screenshot, "image/png", "toto");
+
+            Field delegate = scenario.getClass().getDeclaredField("delegate");
+            delegate.setAccessible(true);
+
+            TestCaseState state = (TestCaseState) delegate.get(scenario);
+            Field testCaseF = state.getClass().getDeclaredField("testCase");
+            testCaseF.setAccessible(true);
+
+            TestCase tC = (TestCase) testCaseF.get(state);
+            Field pickle = tC.getClass().getDeclaredField("pickle");
+            pickle.setAccessible(true);
+
+            Pickle pickleState = (Pickle) pickle.get(tC);
+            List<Step> steps = pickleState.getSteps();
+
+//            Field f = scenario.getClass().getDeclaredField("testCase");
+//            //f.setAccessible(true);
+//            TestCase r = (TestCase) f.get(scenario);
+//
+            //You need to filter out before/after hooks
+            List<PickleStepTestStep> stepDefs = tC.getTestSteps()
+                    .stream()
+                    .filter(x -> x instanceof PickleStepTestStep)
+                    .map(x -> (PickleStepTestStep) x)
+                    .collect(Collectors.toList());
+//
+//
+//            //This object now holds the information about the current step definition
+//            //If you are using pico container
+//            //just store it somewhere in your world state object
+//            //and to make it available in your step definitions.
+            PickleStepTestStep currentStepDef = stepDefs
+                    .get(currentStepDefIndex);
+
+
+            testCase.log(Status.FAIL, currentStepDef.getStep().getText());
+
+
+            AutomTools.closeDriver();
+            extent.flush();
+        }
+        currentStepDefIndex += 1;
+    }
+
+    @After("@Exercice")
+    public void tearDownForUi() {
+        AutomTools.closeDriver();
+        extent.flush();
+    }
+}

--- a/Parcours_IHM_Hightest/src/test/resources/features/ISTQBQuizz.feature
+++ b/Parcours_IHM_Hightest/src/test/resources/features/ISTQBQuizz.feature
@@ -1,0 +1,11 @@
+Feature: Send email with results
+
+  @Exercice
+  Scenario: good answers
+    Given I connect to Hightest
+    And I go to the ToolBox section
+    When I take the French ISTQB Quizz and all my answers are good
+    And I give Julien Baroni's email for him to receive the results
+    When I connect to LinkedIn
+    And I open the results Julien Baroni sent me
+    Then then content of the results indicates "20 question(s) sur 20, soit 100 % de réussite"


### PR DESCRIPTION
Cette PR a pour objet les modifications suivantes : 

- Utilisation du langage Gherkin pour reformuler les étapes du parcours automatisé
- Rajout d'un @AfterStep chargé en cas d'échec, de prendre une capture d'écran et d'indiquer dans le rapport d'exécution la raison pour laquelle l'étape en cours a échoué

